### PR TITLE
Add missing method to RSpec3 formatter

### DIFF
--- a/lib/ci/reporter/rspec3/formatter.rb
+++ b/lib/ci/reporter/rspec3/formatter.rb
@@ -63,6 +63,10 @@ module CI::Reporter
         @suite = TestSuite.new(name)
         @suite.start
       end
+
+      def output
+	@report_manager.filename_for(@suite)        
+      end
     end
 
     ::RSpec::Core::Formatters.register Formatter,

--- a/lib/ci/reporter/rspec3/formatter.rb
+++ b/lib/ci/reporter/rspec3/formatter.rb
@@ -46,6 +46,14 @@ module CI::Reporter
         write_report
       end
 
+      def output
+	# Cannot delegate to @report_manager because:
+        #  -  filename_for is private
+        #  - @suite is Nil at the point this method is called
+	#@report_manager.filename_for(@suite)        
+	"spec/report/dummy-out.txt"
+      end
+
       private
 
       def current_spec
@@ -64,9 +72,6 @@ module CI::Reporter
         @suite.start
       end
 
-      def output
-	@report_manager.filename_for(@suite)        
-      end
     end
 
     ::RSpec::Core::Formatters.register Formatter,


### PR DESCRIPTION
Hi, this is a bit of a pre-emptive pull request, as I'd like a bit of guidance, and wasn't sure what to put into an issue, or what the specs should be.

I encountered the following issue when adding the ci_reporter to a project that contains specs that executes `rake` and specifically looks for the `--format documentation` output
```
 +/home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:186:in `block in duplicate_formatter_exists?': undefined method `output' for #<CI::Reporter::RSpec3::Formatter:0x0000000266db98> (NoMethodError)
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:185:in `any?'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:185:in `duplicate_formatter_exists?'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:178:in `register'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/formatters.rb:147:in `add'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:828:in `add_formatter'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `block in load_formatters_into'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `each'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:117:in `load_formatters_into'
       +	from /home/vagrant/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:23:in `configure'
```

I have a spec file containing:
```
RSpec.describe "My project" do
  def command(cmd)
    Bundler.with_clean_env do
      # Redirect stderr to stdout for simple command execution
      return `#{cmd} 2>&1`
    end
  end

  # ...

  it "should output with --format documentation" do
        expect(command("rake spec")).to include "should package myApp (FAILED - 1)"
   end

end

```

executing `rake` or `rspec` directly works as expected, but with the ci_reporter it fails.

This is only a partial implementation, since with the patch, the tests still fail because the documentation formatter is not used.

Should this be supported?